### PR TITLE
Removing syncing the inventory to the client to avoid packets being too big

### DIFF
--- a/src/main/java/de/maxhenkel/gravestone/tileentity/GraveStoneTileEntity.java
+++ b/src/main/java/de/maxhenkel/gravestone/tileentity/GraveStoneTileEntity.java
@@ -93,7 +93,12 @@ public class GraveStoneTileEntity extends TileEntity {
 
     @Override
     public CompoundNBT getUpdateTag() {
-        return write(new CompoundNBT());
+        CompoundNBT compound = new CompoundNBT();
+        compound.putString(PLAYER_NAME, playerName);
+        compound.putLong(DEATH_TIME, deathTime);
+        compound.putString(PLAYER_UUID, playerUUID);
+        compound.putBoolean(RENDER_HEAD, renderHead);
+        return super.write(compound);
     }
 
     public String getPlayerName() {


### PR DESCRIPTION
Having items in your inventory with huge NBT tags (backpacks, etc) would cause your client to disconnect because the syncing packet was too big to be handled.