### PR TITLE
correctly obtain replacable blocks from ids

### DIFF
--- a/src/main/java/de/maxhenkel/gravestone/util/Tools.java
+++ b/src/main/java/de/maxhenkel/gravestone/util/Tools.java
@@ -105,17 +105,12 @@ public class Tools {
 
 	public static Block getBlock(String name) {
 		try {
-			String[] split = name.split(":");
-			if (split.length == 2) {
-				Block b = (Block) Block.blockRegistry.getObject(new ResourceLocation(split[0], split[1]));
+				Block b = (Block) Block.blockRegistry.getObject(name);
 				if (b.equals(Blocks.air)) {
 					return null;
 				} else {
 					return b;
 				}
-			} else {
-				return null;
-			}
 		} catch (Exception e) {
 			return null;
 		}


### PR DESCRIPTION
This is a pretty simple fix. The method getObject takes a string block id. It was silently throwing an exception because is surrounded by a catch-all. (not how I would do it)

All I did was use getObject correctly so that the returned block will not always be null. This means that the config for replacable blocks will actually work now.