### PR TITLE
Only Sort Inventory If Player Owns the Grave 1.19.2

### DIFF
--- a/src/main/java/de/maxhenkel/gravestone/ServerConfig.java
+++ b/src/main/java/de/maxhenkel/gravestone/ServerConfig.java
@@ -23,6 +23,7 @@ public class ServerConfig extends ConfigBase {
     public final ForgeConfigSpec.BooleanValue friendlyGhost;
     public final ForgeConfigSpec.BooleanValue sneakPickup;
     public final ForgeConfigSpec.BooleanValue breakPickup;
+    public final ForgeConfigSpec.BooleanValue sortOwnerOnly;
 
     public List<Tag<Block>> replaceableBlocks = new ArrayList<>();
 
@@ -52,6 +53,9 @@ public class ServerConfig extends ConfigBase {
         breakPickup = builder
                 .comment("If this is set to true you get your items sorted back into your inventory by breaking the grave")
                 .define("break_pickup", true);
+        sortOwnerOnly = builder
+                .comment("If this is set to true the items from the grave only get sorted if you own that grave")
+                .define("sort_owner_only", true);
     }
 
     @Override

--- a/src/main/java/de/maxhenkel/gravestone/blocks/GraveStoneBlock.java
+++ b/src/main/java/de/maxhenkel/gravestone/blocks/GraveStoneBlock.java
@@ -299,10 +299,11 @@ public class GraveStoneBlock extends Block implements EntityBlock, IItemBlock, S
 
     public NonNullList<ItemStack> fillPlayerInventory(Player player, Death death) {
         NonNullList<ItemStack> additionalItems = NonNullList.create();
-        fillInventory(additionalItems, death.getMainInventory(), player.getInventory().items);
-        fillInventory(additionalItems, death.getArmorInventory(), player.getInventory().armor);
-        fillInventory(additionalItems, death.getOffHandInventory(), player.getInventory().offhand);
-
+        if (!Main.SERVER_CONFIG.sortOwnerOnly.get() || death.getPlayerUUID().equals(player.getUUID())) {
+        	fillInventory(additionalItems, death.getMainInventory(), player.getInventory().items);
+        	fillInventory(additionalItems, death.getArmorInventory(), player.getInventory().armor);
+        	fillInventory(additionalItems, death.getOffHandInventory(), player.getInventory().offhand);
+        }
         additionalItems.addAll(death.getAdditionalItems());
         NonNullList<ItemStack> restItems = NonNullList.create();
         for (ItemStack stack : additionalItems) {
@@ -315,9 +316,9 @@ public class GraveStoneBlock extends Block implements EntityBlock, IItemBlock, S
         return restItems;
     }
 
-    public void fillInventory(List<ItemStack> additionalItems, NonNullList<ItemStack> inventory, NonNullList<ItemStack> playerInv) {
-        for (int i = 0; i < inventory.size(); i++) {
-            ItemStack stack = inventory.get(i);
+    public void fillInventory(List<ItemStack> additionalItems, NonNullList<ItemStack> deathInv, NonNullList<ItemStack> playerInv) {
+        for (int i = 0; i < deathInv.size(); i++) {
+            ItemStack stack = deathInv.get(i);
             if (stack.isEmpty()) {
                 continue;
             }
@@ -325,7 +326,7 @@ public class GraveStoneBlock extends Block implements EntityBlock, IItemBlock, S
             if (!playerStack.isEmpty()) {
                 additionalItems.add(playerStack);
             }
-            inventory.set(i, ItemStack.EMPTY);
+            deathInv.set(i, ItemStack.EMPTY);
             playerInv.set(i, stack);
         }
     }


### PR DESCRIPTION
In pvp scenarios, it is frustrating when player A opens player B's grave and all of player A's items gets replaced by player B's. It is especially annoying when player B's armor is worse than player A. This maintains the convenience of the inventory sorting for grave stone owners, while not screwing over people who win a pvp engagement. 