### PR TITLE
Fix graves always dropping in 1.21.1

### DIFF
--- a/src/main/resources/data/gravestone/loot_table/blocks/gravestone.json
+++ b/src/main/resources/data/gravestone/loot_table/blocks/gravestone.json
@@ -14,14 +14,16 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "enchantments": [
-              {
-                "enchantment": "minecraft:silk_touch",
-                "levels": {
-                  "min": 1
+            "predicates": {
+              "minecraft:enchantments": [
+                {
+                  "enchantments": "minecraft:silk_touch",
+                  "levels": {
+                    "min": 1
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ]


### PR DESCRIPTION
1.20.5 updated some of the formatting for loot table predicates.

1.21 made a minor change by allowing a list of enchantments or tags in the 'minecraft:enchantments' sub-predicate.
https://minecraft.wiki/w/Predicate#History